### PR TITLE
Update pf.conf

### DIFF
--- a/config/action.d/pf.conf
+++ b/config/action.d/pf.conf
@@ -18,8 +18,8 @@
 # also, these rulesets are loaded into (nested) anchors
 # to enable them, add
 #     anchor f2b {
-#        name1
-#        name2
+#        anchor name1
+#        anchor name2
 #        ...
 #     }
 # to your main pf ruleset, where "namei" are the names of the jails


### PR DESCRIPTION
pf.conf comment regarding anchors has wrong syntax. This commit fixes it.

cat /etc/pf.conf
anchor f2b {
  sshd
}

$ sudo service pf reload
Reloading pf rules.
/etc/pf.conf:2: syntax error

New version:

cat /etc/pf.conf
anchor f2b {
  anchor sshd
}

$ sudo service pf reload
Reloading pf rules.
